### PR TITLE
add support for custom delimiter

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,12 +3,27 @@ from typing import List
 
 class StringCalculator:
     def __init__(self,values:str):
-        delimeter_processed = self._process_delimeter(values)
-        self.values = self._extract_numbers(delimeter_processed)
+        self.delimiter = self._get_custom_delimiter(values)
+        delimiter_hint_removed = self._trim_delimiter_hint(values)  # delimeter_hint_removed is for Hidden Temporal Coupling
+        delimiter_processed = self._process_delimiter(delimiter_hint_removed)
+        self.values = self._extract_numbers(delimiter_processed)
+    
+    def _get_custom_delimiter(self,values:str)->str:
+        raw_string = '%r'%values
+        if raw_string[1:3]=="//" and raw_string[4:6]==r"\n":
+            return raw_string[3:4]
+        else:
+            return ","
 
-    def _process_delimeter(self,values:str)->str:
-        delimeter_processed = values.replace("\n",",")
-        return delimeter_processed
+    def _trim_delimiter_hint(self,values:str)->str:
+        raw_string = '%r'%values
+        if raw_string[1:3]=="//" and raw_string[4:6]==r"\n":
+            return raw_string[6:-1]
+        return values
+
+    def _process_delimiter(self,values:str)->str:
+        delimiter_processed = values.replace(self.delimiter,",")
+        return delimiter_processed
 
     def _extract_numbers(self,values:str)->List:
         if values=="":

--- a/test_string_calculator.py
+++ b/test_string_calculator.py
@@ -38,6 +38,6 @@ class TestStringCalculator:
         string_calculator = StringCalculator("0,0,0,0")
         assert string_calculator.get_sum() == 0
 
-    def test_new_line_delimeter_should_be_respected(self):
-        string_calculator = StringCalculator("1\n2,3")
+    def test_string_calculator_should_support_custom_delimiter(self):
+        string_calculator = StringCalculator("//;\n1;2,3")
         assert string_calculator.get_sum() == 6


### PR DESCRIPTION
This PR adds support for custom delimiter, defined between // and \n.

- [x] = Unit test included. 